### PR TITLE
Upgrade to setup-go v5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - run: make check
 
   build:
@@ -27,6 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - run: make build
 
   test:
@@ -35,6 +39,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - run: make test
 
   lint:
@@ -43,6 +49,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - run: make lint
 
   coverage:
@@ -51,6 +59,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - run: make coverage
       - uses: codecov/codecov-action@v3
         with:
@@ -66,4 +76,6 @@ jobs:
       - uses: docker/setup-buildx-action@v2
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - run: make docker e2e

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,6 +21,8 @@ jobs:
 
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GCP_INTERNAL_CONTAINERS_SERVICE_ACCOUNT_KEY }}


### PR DESCRIPTION
Setup-go v5 configures the go mod cache by default and infers the go version from the go.mod.