### PR TITLE
Validate callback and logout paths are unique

### DIFF
--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -62,6 +62,9 @@ func TestValidateConfig(t *testing.T) {
 		{"invalid-redis", "testdata/invalid-redis.json", errCheck{is: ErrInvalidURL}},
 		{"invalid-oidc-uris", "testdata/invalid-oidc-uris.json", errCheck{is: ErrRequiredURL}},
 		{"invalid-health-port", "testdata/invalid-health-port.json", errCheck{is: ErrHealthPortInUse}},
+		{"invalid-callback-uri", "testdata/invalid-callback.json", errCheck{is: ErrMustNotBeRootPath}},
+		{"invalid-logout-path", "testdata/invalid-logout.json", errCheck{is: ErrMustNotBeRootPath}},
+		{"invalid-callback-and-logout-path", "testdata/invalid-callback-logout.json", errCheck{is: ErrMustBeDifferentPath}},
 		{"oidc-dynamic", "testdata/oidc-dynamic.json", errCheck{is: nil}},
 		{"valid", "testdata/mock.json", errCheck{is: nil}},
 	}
@@ -76,7 +79,7 @@ func TestValidateConfig(t *testing.T) {
 
 func TestValidateURLs(t *testing.T) {
 	const (
-		validURL      = "http://fake"
+		validURL      = "http://fake/path"
 		invalidURL    = "ht tp://invalid"
 		validRedisURL = "redis://localhost:6379/0"
 	)
@@ -202,7 +205,7 @@ func TestLoadOIDC(t *testing.T) {
 							Oidc: &oidcv1.OIDCConfig{
 								AuthorizationUri:        "http://fake",
 								TokenUri:                "http://fake",
-								CallbackUri:             "http://fake",
+								CallbackUri:             "http://fake/callback",
 								JwksConfig:              &oidcv1.OIDCConfig_Jwks{Jwks: "fake-jwks"},
 								ClientId:                "fake-client-id",
 								ClientSecret:            "fake-client-secret",
@@ -211,6 +214,7 @@ func TestLoadOIDC(t *testing.T) {
 								ProxyUri:                "http://fake",
 								RedisSessionStoreConfig: &oidcv1.RedisConfig{ServerUri: "redis://localhost:6379/0"},
 								Scopes:                  []string{scopeOIDC},
+								Logout:                  &oidcv1.LogoutConfig{Path: "/logout", RedirectUri: "http://fake"},
 							},
 						},
 					},

--- a/internal/testdata/duplicate-oidc.json
+++ b/internal/testdata/duplicate-oidc.json
@@ -5,7 +5,7 @@
   "default_oidc_config": {
     "authorization_uri": "http://fake",
     "token_uri": "http://fake",
-    "callback_uri": "http://fake",
+    "callback_uri": "http://fake/callback",
     "proxy_uri": "http://fake",
     "jwks": "fake-jwks",
     "client_id": "fake-client-id",
@@ -23,7 +23,7 @@
           "oidc": {
             "authorization_uri": "http://fake",
             "token_uri": "http://fake",
-            "callback_uri": "http://fake",
+            "callback_uri": "http://fake/callback",
             "proxy_uri": "http://fake",
             "jwks": "fake-jwks",
             "client_id": "fake-client-id",

--- a/internal/testdata/invalid-callback-logout.json
+++ b/internal/testdata/invalid-callback-logout.json
@@ -1,0 +1,29 @@
+{
+  "listen_address":  "0.0.0.0",
+  "listen_port": 8080,
+  "log_level": "debug",
+  "chains": [
+    {
+      "name": "mock",
+      "filters": [
+        {
+          "oidc": {
+            "callback_uri": "http://fake/same",
+            "authorization_uri": "http://fake",
+            "token_uri": "http://fake",
+            "client_id": "fake",
+            "client_secret": "fake",
+            "jwks": "fake",
+            "id_token": {
+              "header": "authorization",
+              "preamble": "Bearer"
+            },
+            "logout": {
+              "path": "/same"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/testdata/invalid-callback.json
+++ b/internal/testdata/invalid-callback.json
@@ -1,0 +1,26 @@
+{
+  "listen_address":  "0.0.0.0",
+  "listen_port": 8080,
+  "log_level": "debug",
+  "chains": [
+    {
+      "name": "mock",
+      "filters": [
+        {
+          "oidc": {
+            "callback_uri": "http://fake",
+            "authorization_uri": "http://fake",
+            "token_uri": "http://fake",
+            "client_id": "fake",
+            "client_secret": "fake",
+            "jwks": "fake",
+            "id_token": {
+              "header": "authorization",
+              "preamble": "Bearer"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/testdata/invalid-logout.json
+++ b/internal/testdata/invalid-logout.json
@@ -1,0 +1,29 @@
+{
+  "listen_address":  "0.0.0.0",
+  "listen_port": 8080,
+  "log_level": "debug",
+  "chains": [
+    {
+      "name": "mock",
+      "filters": [
+        {
+          "oidc": {
+            "callback_uri": "http://fake/callback",
+            "authorization_uri": "http://fake",
+            "token_uri": "http://fake",
+            "client_id": "fake",
+            "client_secret": "fake",
+            "jwks": "fake",
+            "id_token": {
+              "header": "authorization",
+              "preamble": "Bearer"
+            },
+            "logout": {
+              "path": "/"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/testdata/invalid-oidc-override.json
+++ b/internal/testdata/invalid-oidc-override.json
@@ -10,7 +10,7 @@
           "oidc_override": {
             "authorization_uri": "http://fake",
             "token_uri": "http://fake",
-            "callback_uri": "http://fake",
+            "callback_uri": "http://fake/callback",
             "proxy_uri": "http://fake",
             "jwks": "fake-jwks",
             "client_id": "fake-client-id",

--- a/internal/testdata/invalid-oidc-uris.json
+++ b/internal/testdata/invalid-oidc-uris.json
@@ -8,7 +8,7 @@
       "filters": [
         {
           "oidc": {
-            "callback_uri": "http://fake",
+            "callback_uri": "http://fake/callback",
             "proxy_uri": "http://fake",
             "client_id": "fake-client-id",
             "client_secret": "fake-client-secret",

--- a/internal/testdata/invalid-redis.json
+++ b/internal/testdata/invalid-redis.json
@@ -10,7 +10,7 @@
           "oidc": {
             "authorization_uri": "http://fake",
             "token_uri": "http://fake",
-            "callback_uri": "http://fake",
+            "callback_uri": "http://fake/callback",
             "proxy_uri": "http://fake",
             "jwks": "fake-jwks",
             "client_id": "fake-client-id",

--- a/internal/testdata/multiple-oidc.json
+++ b/internal/testdata/multiple-oidc.json
@@ -10,7 +10,7 @@
           "oidc": {
             "authorization_uri": "http://fake",
             "token_uri": "http://fake",
-            "callback_uri": "http://fake",
+            "callback_uri": "http://fake/callback",
             "proxy_uri": "http://fake",
             "jwks": "fake-jwks",
             "client_id": "fake-client-id",
@@ -25,7 +25,7 @@
           "oidc": {
             "authorization_uri": "http://fake",
             "token_uri": "http://fake",
-            "callback_uri": "http://fake",
+            "callback_uri": "http://fake/callback",
             "proxy_uri": "http://fake",
             "jwks": "fake-jwks",
             "client_id": "fake-client-id",

--- a/internal/testdata/oidc-dynamic.json
+++ b/internal/testdata/oidc-dynamic.json
@@ -9,7 +9,7 @@
         {
           "oidc": {
             "configuration_uri": "http://fake",
-            "callback_uri": "http://fake",
+            "callback_uri": "http://fake/callback",
             "proxy_uri": "http://fake",
             "client_id": "fake-client-id",
             "client_secret": "fake-client-secret",

--- a/internal/testdata/oidc-override.json
+++ b/internal/testdata/oidc-override.json
@@ -5,7 +5,7 @@
   "default_oidc_config": {
     "authorization_uri": "http://default",
     "token_uri": "http://default",
-    "callback_uri": "http://fake",
+    "callback_uri": "http://fake/callback",
     "proxy_uri": "http://fake"
   },
   "chains": [
@@ -25,6 +25,10 @@
             },
             "redis_session_store_config": {
               "server_uri": "tcp://localhost:6379/0"
+            },
+            "logout": {
+              "path": "/logout",
+              "redirect_uri": "http://fake"
             }
           }
         }

--- a/internal/testdata/oidc.json
+++ b/internal/testdata/oidc.json
@@ -10,7 +10,7 @@
           "oidc": {
             "authorization_uri": "http://fake",
             "token_uri": "http://fake",
-            "callback_uri": "http://fake",
+            "callback_uri": "http://fake/callback",
             "proxy_uri": "http://fake",
             "jwks": "fake-jwks",
             "client_id": "fake-client-id",
@@ -21,6 +21,10 @@
             },
             "redis_session_store_config": {
               "server_uri": "redis://localhost:6379/0"
+            },
+            "logout": {
+              "path": "/logout",
+                "redirect_uri": "http://fake"
             }
           }
         }


### PR DESCRIPTION
callback and logout paths must be unique from the root path so that the authservice can identify each kind of request.