### PR TITLE
Bring back keycloak logs to debug level

### DIFF
--- a/e2e/keycloak/authz-config.json
+++ b/e2e/keycloak/authz-config.json
@@ -1,7 +1,7 @@
 {
   "listen_address": "0.0.0.0",
   "listen_port": 10003,
-  "log_level": "info",
+  "log_level": "debug",
   "chains": [
     {
       "name": "keycloak",


### PR DESCRIPTION
This was an unintentional change in the previous PR. Let's just keep e2e tests at debug level so that we have all logs to troubleshoot.