### PR TITLE
Add a e2e to verify gw https redirect works

### DIFF
--- a/e2e/istio/cluster/istiogw-config.yaml
+++ b/e2e/istio/cluster/istiogw-config.yaml
@@ -25,6 +25,11 @@ service:
       nodePort: 30000  # Make it accessible form the host without having to install MetalLB or others
       protocol: TCP
       targetPort: 443
+    - name: http
+      port: 80
+      nodePort: 30002
+      protocol: TCP
+      targetPort: 80
 
 # Clear the default resources to allow it to run in very constrained local environments
 # without explicitly requesting more memory than the one that might be available in the

--- a/e2e/istio/cluster/kind-config.yaml
+++ b/e2e/istio/cluster/kind-config.yaml
@@ -23,3 +23,5 @@ nodes:
         hostPort: 30000
       - containerPort: 30001
         hostPort: 30001
+      - containerPort: 30002
+        hostPort: 30002

--- a/e2e/istio/cluster/manifests/ingress-gateway.yaml
+++ b/e2e/istio/cluster/manifests/ingress-gateway.yaml
@@ -30,6 +30,14 @@ spec:
       tls:
         mode: SIMPLE
         credentialName: http-echo-certs
+    - hosts:
+      - "http-echo.authservice.internal"
+      port:
+        number: 80
+        name: http
+        protocol: HTTP
+      tls:
+        httpsRedirect: true
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService


### PR DESCRIPTION
Trying to reproduce this https://github.com/istio-ecosystem/authservice/issues/232
I added the case in the e2e istio suite.

So the istio gateway accepts plain HTTP connections on port 80 (30002) and redirects to por 443 (30000) without losing any tokens.