### PR TITLE
Configure FIPS builds

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,17 @@
+# Copyright 2024 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 codecov:
   # we build and upload only a single coverage file, so we don't need to wait for other CI
   # jobs to complete for us to see the coverage results

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: CI
 
 on:

--- a/.github/workflows/fips.yaml
+++ b/.github/workflows/fips.yaml
@@ -12,46 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Publish
+name: FIPS
 
 on:
   push:
-    tags: ['v[0-9]+.[0-9]+.[0-9]+**']  # Ex. v0.2.0, v0.2.1-rc2
+    branches:
+      - main
+      - release-**
+    tags: [ 'v[0-9]+.[0-9]+.[0-9]+**' ]  # Ex. v0.2.0, v0.2.1-rc2
   workflow_dispatch: {}
 
 env:
   GOPROXY: https://proxy.golang.org
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: "Set release tag"
-        if: ${{ github.ref_type == 'tag' }}
-        shell: bash
-        run: |
-          # Set the VERSION to force the version of the Docker images
-          echo "VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
-
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-
-      - run: make check
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - run: make docker-push
-      - run: make docker-push-fips
-
-      - uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: bin/authservice-*
-          draft: true
-          generate_release_notes: true
+      - run: make fips
+      - run: make docker-fips

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,11 @@ FROM scratch
 ARG TARGETARCH
 ARG TARGETOS
 ARG REPO
+ARG FLAVOR
 
 LABEL org.opencontainers.image.source=${REPO}
 LABEL org.opencontainers.image.description="Move OIDC token acquisition out of your app code and into the Istio mesh"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
-ADD bin/authservice-static-${TARGETOS}-${TARGETARCH} /usr/local/bin/authservice
+ADD bin/authservice-${FLAVOR}-${TARGETOS}-${TARGETARCH} /usr/local/bin/authservice
 ENTRYPOINT ["/usr/local/bin/authservice"]

--- a/cmd/fips.go
+++ b/cmd/fips.go
@@ -1,0 +1,27 @@
+// Copyright 2024 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build boringcrypto
+
+package main
+
+import (
+	"crypto/boring"
+	"fmt"
+)
+
+// This line will only be printed in the output if boringcrypto is enabled.
+func init() {
+	fmt.Println("FIPS: boringcrypto enabled:", boring.Enabled())
+}

--- a/env.mk
+++ b/env.mk
@@ -14,6 +14,7 @@
 
 ROOT      := $(shell git rev-parse --show-toplevel)
 GO_MODULE := $(shell sed -ne 's/^module //gp' $(ROOT)/go.mod)
+NAME      ?= authservice
 
 -include $(ROOT)/.makerc  # Pick up any local overrides.
 
@@ -23,8 +24,8 @@ LICENSER      ?= github.com/liamawhite/licenser@v0.6.1-0.20210729145742-be6c77bf
 KIND          ?= sigs.k8s.io/kind@v0.18.0
 ENVTEST       ?= sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
-NAME    ?= authservice
-TARGETS ?= linux-amd64 linux-arm64 #darwin-amd64 darwin-arm64
+TARGETS      ?= linux-amd64 linux-arm64 #darwin-amd64 darwin-arm64
+FIPS_TARGETS := $(filter linux-%,$(TARGETS))
 
 # DOCKER_HUB is exported so that it can be referenced in e2e docker compose files
 export DOCKER_HUB     ?= $(GO_MODULE:github.com/%=ghcr.io/%)
@@ -38,6 +39,7 @@ else
 DOCKER_TAG ?= $(shell git rev-parse HEAD)
 endif
 
+OS := $(shell uname)
 export ARCH := $(shell uname -m)
 ifeq ($(ARCH),x86_64)
 export ARCH := amd64

--- a/run-in-docker.sh
+++ b/run-in-docker.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script runs the given command in a Docker container.
+
+if [[ ${#} -lt 2 ]]; then
+    echo "Usage: ${0} <platform> <command>"
+    echo "  e.g: ${0} linux/amd64 make help"
+    exit 1
+fi
+
+set -e
+
+ROOT=$(git rev-parse --show-toplevel)
+GO_VERSION=$(sed -ne 's/^go //gp' "${ROOT}/go.mod")
+BUILD_IMAGE="golang:${GO_VERSION}"
+
+docker run \
+    --rm \
+    --platform "${1}" \
+    -v "${PWD}":/source \
+    -v "$(go env GOMODCACHE)":/go/pkg/mod \
+    -e GOPROXY="$(go env GOPROXY)" \
+    -e GOPRIVATE="$(go env GOPRIVATE)" \
+    -w /source \
+    "${BUILD_IMAGE}" \
+    /bin/bash -c "${*:2}"


### PR DESCRIPTION
Adds a set of make targets to build FIPS binaries and FIPS Docker images.
Note that to build FIPS in non-Linux hosts, a convenience script is used to run the build inside a Linux Docker container.
With this change, an additional Docker image with the `-fips` suffix in the tag is generated.