### PR TITLE
Remove workflow_dispatch to prevent manual pushes of images tot he public repo

### DIFF
--- a/.github/workflows/fips.yaml
+++ b/.github/workflows/fips.yaml
@@ -20,7 +20,6 @@ on:
       - main
       - release-**
     tags: [ 'v[0-9]+.[0-9]+.[0-9]+**' ]  # Ex. v0.2.0, v0.2.1-rc2
-  workflow_dispatch: {}
 
 env:
   GOPROXY: https://proxy.golang.org

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,6 @@ name: Publish
 on:
   push:
     tags: ['v[0-9]+.[0-9]+.[0-9]+**']  # Ex. v0.2.0, v0.2.1-rc2
-  workflow_dispatch: {}
 
 env:
   GOPROXY: https://proxy.golang.org


### PR DESCRIPTION
This was useful while testing, but we don't want now to have manual pushes to the public docker registry. Onyl controlled releases.