### PR TITLE
Properly set metadata in multi-arch images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,5 @@ ARG TARGETOS
 ARG REPO
 ARG FLAVOR
 
-LABEL org.opencontainers.image.source=${REPO}
-LABEL org.opencontainers.image.description="Move OIDC token acquisition out of your app code and into the Istio mesh"
-LABEL org.opencontainers.image.licenses="Apache-2.0"
-
 ADD bin/authservice-${FLAVOR}-${TARGETOS}-${TARGETARCH} /usr/local/bin/authservice
 ENTRYPOINT ["/usr/local/bin/authservice"]

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,8 @@ docker/%: $(OUTDIR)/$(NAME)-$$(FLAVOR)-$$(notdir %)
 		--platform $(PLATFORM) \
 		--build-arg REPO=https://$(GO_MODULE) \
 		--build-arg FLAVOR=$(FLAVOR) \
+		$(subst org.,--label org.,$(DOCKER_METADATA)) \
+		$(subst org.,--annotation index:org.,$(DOCKER_METADATA)) \
 		-t $(DOCKER_HUB)/$(NAME):latest-$(DOCKER_ARCH)$(TAG_SUFFIX) \
 		-t $(DOCKER_HUB)/$(NAME):$(DOCKER_TAG)-$(DOCKER_ARCH)$(TAG_SUFFIX) \
 		.
@@ -182,6 +184,8 @@ docker-push/%:
 		--platform $(PLATFORMS) \
 		--build-arg REPO=https://$(GO_MODULE) \
 		--build-arg FLAVOR=$(@F) \
+		$(subst org.,--label org.,$(DOCKER_METADATA)) \
+		$(subst org.,--annotation index:org.,$(DOCKER_METADATA)) \
 		-t $(DOCKER_HUB)/$(NAME):$(DOCKER_TAG)$(TAG_SUFFIX) \
 		.
 

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,6 @@ docker/%: $(OUTDIR)/$(NAME)-$$(FLAVOR)-$$(notdir %)
 		--build-arg REPO=https://$(GO_MODULE) \
 		--build-arg FLAVOR=$(FLAVOR) \
 		$(subst org.,--label org.,$(DOCKER_METADATA)) \
-		$(subst org.,--annotation index:org.,$(DOCKER_METADATA)) \
 		-t $(DOCKER_HUB)/$(NAME):latest-$(DOCKER_ARCH)$(TAG_SUFFIX) \
 		-t $(DOCKER_HUB)/$(NAME):$(DOCKER_TAG)-$(DOCKER_ARCH)$(TAG_SUFFIX) \
 		.

--- a/env.mk
+++ b/env.mk
@@ -32,12 +32,22 @@ export DOCKER_HUB     ?= $(GO_MODULE:github.com/%=ghcr.io/%)
 DOCKER_TARGETS        ?= linux-amd64 linux-arm64
 DOCKER_BUILDER_NAME   ?= $(NAME)-builder
 
+REVISION := $(shell git rev-parse HEAD)
 ifneq ($(strip $(VERSION)),)
 # Remove the suffix as we want N.N.N instead of vN.N.N
 DOCKER_TAG ?= $(strip $(VERSION:v%=%))
 else
-DOCKER_TAG ?= $(shell git rev-parse HEAD)
+DOCKER_TAG ?= $(REVISION)
 endif
+
+# Docker metadata
+DOCKER_METADATA := \
+	org.opencontainers.image.title=$(NAME) \
+	org.opencontainers.image.description="Move OIDC token acquisition out of your app code and into the Istio mesh" \
+	org.opencontainers.image.licenses="Apache-2.0" \
+	org.opencontainers.image.source=https://$(GO_MODULE) \
+	org.opencontainers.image.version=$(DOCKER_TAG) \
+	org.opencontainers.image.revision=$(REVISION)
 
 # In non-Linux systems, use Docker to build FIPS-compliant binaries.
 OS := $(shell uname)


### PR DESCRIPTION
Add annotations to the multi-arch images so that metadata properly shows in the Package registry. See the notes on multi-arch images in: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images